### PR TITLE
Tweaked implementation of empty-scene function in #321

### DIFF
--- a/racketscript-extras/racketscript/htdp/image.rkt
+++ b/racketscript-extras/racketscript/htdp/image.rkt
@@ -268,9 +268,8 @@
              (#js.ctx.lineTo (posn-x pt) (posn-y pt))
              (loop (cdr points)))))))])
 
-(define (empty-scene width height)
-  (overlay (rectangle width height 'solid 'white)
-           (rectangle width height 'outline 'black)))
+(define (empty-scene width height color)
+  (rectangle width height "solid" color))
 
 (define (text txt size color)
   (new (Text txt

--- a/racketscript-extras/racketscript/htdp/image.rkt
+++ b/racketscript-extras/racketscript/htdp/image.rkt
@@ -268,8 +268,9 @@
              (#js.ctx.lineTo (posn-x pt) (posn-y pt))
              (loop (cdr points)))))))])
 
-(define (empty-scene width height color)
-  (rectangle width height "solid" color))
+(define (empty-scene width height)
+  (rectangle width height "solid" "white")
+  (rectangle width height "outline" "black"))   
 
 (define (text txt size color)
   (new (Text txt


### PR DESCRIPTION
Thanks for submitting! This builds on the code from #321. I tested the original PR changes on your orbiting bodies example but found that it still produced the white background, so I went in and altered the empty-scene function a bit to take a color parameter and to draw a single rectangle of the given color and size, which I got to work with a few different colors.